### PR TITLE
Disallow shortcuts that match menu inputs

### DIFF
--- a/src/demos.asm
+++ b/src/demos.asm
@@ -42,6 +42,13 @@ org $90E817
 endif
 warnpc $90E81A
 
+
+; unlock the fourth demo set
+; normally requires watching credits
+org $808262
+    LDA #$0004
+
+
 if !FEATURE_PAL
 org $919DAA
 else

--- a/src/gamemode.asm
+++ b/src/gamemode.asm
@@ -128,6 +128,11 @@ gamemode_shortcuts:
     CLC : RTS
   .check_shortcuts
 
+    LDA !IH_CONTROLLER_PRI : AND !sram_ctrl_menu : CMP !sram_ctrl_menu : BNE .skip_menu
+    AND !IH_CONTROLLER_PRI_NEW : BEQ .skip_menu
+    JMP .menu
+  .skip_menu
+
 if !FEATURE_SD2SNES
     LDA !IH_CONTROLLER_PRI : CMP !sram_ctrl_save_state : BNE .skip_save_state
     AND !IH_CONTROLLER_PRI_NEW : BEQ .skip_save_state
@@ -167,7 +172,7 @@ endif
 
     ; Check if any less common shortcuts are configured
     LDA !ram_game_mode_extras : BNE .check_less_common_shortcuts
-    JMP .check_menu
+    JMP .no_shortcuts
   .check_less_common_shortcuts
 
     LDA !IH_CONTROLLER_PRI : AND !sram_ctrl_inc_custom_preset : CMP !sram_ctrl_inc_custom_preset : BNE .skip_next_preset_slot
@@ -210,12 +215,7 @@ endif
     JMP .update_timers
   .skip_update_timers
 
-  .check_menu
-    LDA !IH_CONTROLLER_PRI : AND !sram_ctrl_menu : CMP !sram_ctrl_menu : BNE .skip_check_menu
-    AND !IH_CONTROLLER_PRI_NEW : BEQ .skip_check_menu
-    JMP .menu
-  .skip_check_menu
-
+  .no_shortcuts
     ; No shortcuts matched, CLC so we won't skip normal gameplay
     CLC : RTS
 

--- a/src/menu.asm
+++ b/src/menu.asm
@@ -1712,6 +1712,16 @@ cm_ctrl_mode:
     LDA !ram_cm_ctrl_timer : INC : STA !ram_cm_ctrl_timer
     CMP.w #0060 : BNE .next_frame
 
+    ; disallow inputs that match the menu shortcut
+    LDA !DP_CtrlInput : CMP.w #!sram_ctrl_menu : BEQ .store
+    LDA !IH_CONTROLLER_PRI : CMP !sram_ctrl_menu : BNE .store
+    %sfxfail()
+    ; set cursor position to 0 (menu shortcut)
+    LDX !ram_cm_stack_index
+    LDA #$0000 : STA !ram_cm_cursor_stack,X
+    BRA .exit
+
+  .store
     ; Store controller input to SRAM
     LDA !IH_CONTROLLER_PRI : STA [!DP_CtrlInput]
     JSL GameModeExtras


### PR DESCRIPTION
This commit prevents setting a controller shortcut if it matches the inputs for the menu shortcut. It also moves the menu shortcut check to the top of the list so it will always have priority.