### PR TITLE
Combine Zeb/Metroid events and add speedbooster quake

### DIFF
--- a/src/defines.asm
+++ b/src/defines.asm
@@ -339,11 +339,7 @@
 !ram_cm_etanks = !WRAM_MENU_START+$AC
 !ram_cm_reserve = !WRAM_MENU_START+$AE
 
-!ram_cm_zeb1 = !WRAM_MENU_START+$90
-!ram_cm_zeb2 = !WRAM_MENU_START+$92
-!ram_cm_zeb3 = !WRAM_MENU_START+$94
-!ram_cm_zeb4 = !WRAM_MENU_START+$96
-!ram_cm_zebmask = !WRAM_MENU_START+$98
+!ram_cm_zebmask = !WRAM_MENU_START+$90
 
 !ram_cm_ceres_seconds = !WRAM_MENU_START+$90
 !ram_cm_zebes_seconds = !WRAM_MENU_START+$92

--- a/src/defines.asm
+++ b/src/defines.asm
@@ -340,6 +340,7 @@
 !ram_cm_reserve = !WRAM_MENU_START+$AE
 
 !ram_cm_zebmask = !WRAM_MENU_START+$90
+!ram_cm_metmask = !WRAM_MENU_START+$92
 
 !ram_cm_ceres_seconds = !WRAM_MENU_START+$90
 !ram_cm_zebes_seconds = !WRAM_MENU_START+$92

--- a/src/flagmenu.asm
+++ b/src/flagmenu.asm
@@ -900,16 +900,7 @@ events_metroid4:
     %cm_toggle_bit("4th Metroids Cleared", $7ED822, #$0008, #0)
 
 events_zebettites:
-    dw !ACTION_CHOICE
-    dl #!ram_cm_zebmask
-    dw .routine
-    db #$28, "Zebs Killed", #$FF
-    db #$28, "          0", #$FF
-    db #$28, "          1", #$FF
-    db #$28, "          2", #$FF
-    db #$28, "          3", #$FF
-    db #$28, "          4", #$FF
-    db #$FF
+    %cm_numfield("Zebs Killed", !ram_cm_zebmask, 0, 4, 1, 1, #.routine)
   .routine
     CMP #$0000 : BEQ .done
     CMP #$0001 : BEQ .one

--- a/src/flagmenu.asm
+++ b/src/flagmenu.asm
@@ -827,24 +827,42 @@ eventflags_setmapstations:
 
 eventflags_prepare_events_menu:
 {
+    ; Zebettites
     LDA $7ED820 : AND #$0038
-    CMP #$0020 : BEQ .four
-    CMP #$0018 : BEQ .three
-    CMP #$0010 : BEQ .two
-    CMP #$0008 : BEQ .one
-    BRA .done
-
-  .one
-    LDA #$0001 : BRA .done
-  .two
-    LDA #$0002 : BRA .done
-  .three
-    LDA #$0003 : BRA .done
-  .four
-    LDA #$0004
-
-  .done
+    CMP #$0020 : BEQ .fourZeb
+    CMP #$0018 : BEQ .threeZeb
+    CMP #$0010 : BEQ .twoZeb
+    CMP #$0008 : BEQ .oneZeb
+    LDA #$0000 : BRA .doneZeb
+  .fourZeb
+    LDA #$0004 : BRA .doneZeb
+  .threeZeb
+    LDA #$0003 : BRA .doneZeb
+  .twoZeb
+    LDA #$0002 : BRA .doneZeb
+  .oneZeb
+    LDA #$0001 : BRA .doneZeb
+  .doneZeb
     STA !ram_cm_zebmask
+
+    ; Metroids
+    LDA $7ED822 : AND #$000F
+    BIT #$0008 : BNE .fourMet
+    BIT #$0004 : BNE .threeMet
+    BIT #$0002 : BNE .twoMet
+    BIT #$0001 : BNE .oneMet
+    LDA #$0000 : BRA .doneMet
+  .fourMet
+    LDA #$0004 : BRA .doneMet
+  .threeMet
+    LDA #$0003 : BRA .doneMet
+  .twoMet
+    LDA #$0002 : BRA .doneMet
+  .oneMet
+    LDA #$0001 : BRA .doneMet
+  .doneMet
+    STA !ram_cm_metmask
+
     %setmenubank()
     JML action_submenu
 }
@@ -855,10 +873,7 @@ EventsMenu:
     dw #events_maridiatubebroken
     dw #events_shaktool
     dw #events_chozoacid
-    dw #events_metroid1
-    dw #events_metroid2
-    dw #events_metroid3
-    dw #events_metroid4
+    dw #events_metroids
     dw #events_zebettites
     dw #events_mb1glass
     dw #events_zebesexploding
@@ -887,17 +902,26 @@ events_shaktool:
 events_chozoacid:
     %cm_toggle_bit("Chozo Lowered Acid", $7ED821, #$0010, #0)
 
-events_metroid1:
-    %cm_toggle_bit("1st Metroids Cleared", $7ED822, #$0001, #0)
+events_metroids:
+    %cm_numfield("Metroid Rooms Cleared", !ram_cm_metmask, 0, 4, 1, 1, #.routine)
+  .routine
+    CMP #$0000 : BEQ .done
+    CMP #$0001 : BEQ .one
+    CMP #$0002 : BEQ .two
+    CMP #$0003 : BEQ .three
 
-events_metroid2:
-    %cm_toggle_bit("2nd Metroids Cleared", $7ED822, #$0002, #0)
+    LDA #$000F : BRA .done
+  .three
+    LDA #$0007 : BRA .done
+  .two
+    LDA #$0003 : BRA .done
+  .one
+    LDA #$0001 : BRA .done
 
-events_metroid3:
-    %cm_toggle_bit("3rd Metroids Cleared", $7ED822, #$0004, #0)
-
-events_metroid4:
-    %cm_toggle_bit("4th Metroids Cleared", $7ED822, #$0008, #0)
+  .done
+    STA $C1
+    LDA $7ED822 : AND #$FFF0 : ORA $C1 : STA $7ED822
+    RTL
 
 events_zebettites:
     %cm_numfield("Zebs Killed", !ram_cm_zebmask, 0, 4, 1, 1, #.routine)

--- a/src/symbols.asm
+++ b/src/symbols.asm
@@ -323,6 +323,7 @@ ram_cm_etanks = !ram_cm_etanks ; !WRAM_MENU_START+$AC
 ram_cm_reserve = !ram_cm_reserve ; !WRAM_MENU_START+$AE
 
 ram_cm_zebmask = !ram_cm_zebmask ; !WRAM_MENU_START+$90
+ram_cm_metmask = !ram_cm_metmask ; !WRAM_MENU_START+$92
 
 ram_cm_ceres_seconds = !ram_cm_ceres_seconds ; !WRAM_MENU_START+$90
 ram_cm_zebes_seconds = !ram_cm_zebes_seconds ; !WRAM_MENU_START+$92

--- a/src/symbols.asm
+++ b/src/symbols.asm
@@ -322,11 +322,7 @@ ram_cm_plasma = !ram_cm_plasma ; !WRAM_MENU_START+$AA
 ram_cm_etanks = !ram_cm_etanks ; !WRAM_MENU_START+$AC
 ram_cm_reserve = !ram_cm_reserve ; !WRAM_MENU_START+$AE
 
-ram_cm_zeb1 = !ram_cm_zeb1 ; !WRAM_MENU_START+$90
-ram_cm_zeb2 = !ram_cm_zeb2 ; !WRAM_MENU_START+$92
-ram_cm_zeb3 = !ram_cm_zeb3 ; !WRAM_MENU_START+$94
-ram_cm_zeb4 = !ram_cm_zeb4 ; !WRAM_MENU_START+$96
-ram_cm_zebmask = !ram_cm_zebmask ; !WRAM_MENU_START+$98
+ram_cm_zebmask = !ram_cm_zebmask ; !WRAM_MENU_START+$90
 
 ram_cm_ceres_seconds = !ram_cm_ceres_seconds ; !WRAM_MENU_START+$90
 ram_cm_zebes_seconds = !ram_cm_zebes_seconds ; !WRAM_MENU_START+$92


### PR DESCRIPTION
Combines the four zebettite and metroid events into single menu options. Players can select how many zebettites are destroyed, or how many metroid rooms have been cleared. This saves us some space in the events menu, and uses a bit less (shared) RAM.
Added the speedbooster lavaquake event.